### PR TITLE
fix topMovieByRevenue query endpoint sort function

### DIFF
--- a/s2v2.js
+++ b/s2v2.js
@@ -82,7 +82,7 @@ const resolvers = {
       return movies;
     },
     topMovieByRevenue: (root, args, context) => {
-      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieA.revenue < movieB.revenue));
+      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieB.revenue - movieA.revenue));
 
       return moviesByRevenueDesc[0];
     }

--- a/s2v3.js
+++ b/s2v3.js
@@ -82,7 +82,7 @@ const resolvers = {
       return movies;
     },
     topMovieByRevenue: (root, args, context) => {
-      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieA.revenue < movieB.revenue));
+      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieB.revenue - movieA.revenue));
 
       return moviesByRevenueDesc[0];
     }

--- a/s3v2.js
+++ b/s3v2.js
@@ -92,7 +92,7 @@ const resolvers = {
       return movies;
     },
     topMovieByRevenue: (root, args, context) => {
-      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieA.revenue < movieB.revenue));
+      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieB.revenue - movieA.revenue));
 
       return moviesByRevenueDesc[0];
     }

--- a/s3v3.js
+++ b/s3v3.js
@@ -118,7 +118,7 @@ const resolvers = {
       return movies;
     },
     topMovieByRevenue: (root, args, context) => {
-      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieA.revenue < movieB.revenue));
+      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieB.revenue - movieA.revenue));
 
       return moviesByRevenueDesc[0];
     }

--- a/s4v1.js
+++ b/s4v1.js
@@ -121,7 +121,7 @@ const resolvers = {
       return movies;
     },
     topMovieByRevenue: (root, args, context) => {
-      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieA.revenue < movieB.revenue));
+      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieB.revenue - movieA.revenue));
 
       return moviesByRevenueDesc[0];
     },

--- a/s4v2.js
+++ b/s4v2.js
@@ -121,7 +121,7 @@ const resolvers = {
       return movies;
     },
     topMovieByRevenue: (root, args, context) => {
-      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieA.revenue < movieB.revenue));
+      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieB.revenue - movieA.revenue));
 
       return moviesByRevenueDesc[0];
     },

--- a/s4v3.js
+++ b/s4v3.js
@@ -121,7 +121,7 @@ const resolvers = {
       return movies;
     },
     topMovieByRevenue: (root, args, context) => {
-      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieA.revenue < movieB.revenue));
+      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieB.revenue - movieA.revenue));
 
       return moviesByRevenueDesc[0];
     },

--- a/s4v4.js
+++ b/s4v4.js
@@ -129,7 +129,7 @@ const resolvers = {
       return movies;
     },
     topMovieByRevenue: (root, args, context) => {
-      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieA.revenue < movieB.revenue));
+      const moviesByRevenueDesc = movies.sort((movieA, movieB) => (movieB.revenue - movieA.revenue));
 
       return moviesByRevenueDesc[0];
     },


### PR DESCRIPTION
I found this mistake when going through the intro to graphql course. This endpoint does not return the correct data. Javascript's Array.prototype.sort predicate functions must return an integer value. With this change, the list will be accurately sorted by revenue in descending order.